### PR TITLE
Switch date format from %G to %Y.

### DIFF
--- a/mk/dicts.mk
+++ b/mk/dicts.mk
@@ -234,7 +234,7 @@ release-dictd: $(RELEASE_DIR) $(call gen_release_path,dictd) \
 #### targets for evolutionary platform
 ######################################
 
-date=$(shell date +%G-%m-%d)
+date=$(shell date +%Y-%m-%d)
 
 install-base: $(dictname).dict.dz $(dictname).index
 	install -d $(DESTDIR)/$(PREFIX)/share/dictd


### PR DESCRIPTION
The date format placeholder %G is replaced with the ISO 8601 week-based year. This is usually the current year, except for the last few days of the year when it is the current year + 1. I've changed it to %Y which is the current year.