### PR TITLE
Use PyGlossary to generate StarDict glossaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,12 @@ Now tei2slob will be in your path. For new shells, you will have to execute
 `source env-slob/bin/activate` again, or put env-slob/bin/tei2slob into your
 PATH.
 
+
+For creating StarDict files, you need to install [PyGlossary](https://github.com/ilius/pyglossary):
+
+	pip install git+https://github.com/ilius/pyglossary.git
+
+
+
 Sebastian Humenda, Mar 2018
 

--- a/importers/pyproject.toml
+++ b/importers/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "fd_import"
+version = "0.1"
+description = "FreeDict parser and dictionary import helpers"
+classifiers = [
+    "License :: GPL-3.0-or-later",
+    ]
+requires-python = ">=3.5"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/importers/setup.cfg
+++ b/importers/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = "fd_import
+version = 0.1.0
+description = FreeDict tooling for the build system
+
+[options]
+zip_safe = False
+include_package_data = True
+packages = fd_import
+#package_dir=fd_import
+

--- a/mk/dicts.mk
+++ b/mk/dicts.mk
@@ -44,7 +44,7 @@ DISTFILES_BINARY = $(foreach f, README README.md README.txt README.rst \
 		$(wildcard $(f))) # only consider these files if they do exist
 
 PREFIX ?= /usr
-DESTDIR ?= 
+DESTDIR ?=
 
 ################
 # Common Function Definitions
@@ -67,7 +67,7 @@ dict_tei_source = $(dictname).tei
 
 #######################
 #### Phonetics import
-#### 
+####
 #### This needs to come before all others, so that the relevant functions are
 #### defined correctly.
 #######################
@@ -335,44 +335,19 @@ release-src: $(call gen_release_path,src) $(call gen_release_hashpath,src)
 ##################################
 
 # This tool comes with stardict
-DICTD2DIC ?= dictd2dic
+PYGLOSSARY = pyglossary
 
-# This is hardcoded into dictd2dic :(
-stardict_prefix = dictd_www.dict.org_
+# Can we remove this?
+stardict_prefix =
 
-# idxhead is required to preexist by dictd2dic. The reason is not documented.
-$(dictname).idxhead:
-	echo -n "" > $@
-
-$(stardict_prefix)$(dictname).idx $(stardict_prefix)$(dictname).dict.dz \
-	dictd2dic.out: $(dictname).index $(dictname).dict $(dictname).idxhead
-	$(DICTD2DIC) $(dictname) >dictd2dic.out
+$(stardict_prefix)$(dictname).ifo $(stardict_prefix)$(dictname).idx.gz \
+	$(stardict_prefix)$(dictname).dict.dz pyglossary-stardict.out: $(dictname).tei
+	$(PYGLOSSARY) $(dictname).tei $(stardict_prefix)$(dictname).ifo >pyglossary-stardict.out
 	gzip -9 $(stardict_prefix)$(dictname).idx
 
-# $(wordcount) and $(idxfilesize) are a target-specific variables
-$(stardict_prefix)$(dictname).ifo: \
-	wordcount=$(word 2, $(shell tail -n1 dictd2dic.out))
-
-$(stardict_prefix)$(dictname).ifo: \
-	idxfilesize=$(strip $(shell zcat $(stardict_prefix)$(dictname).idx | wc -c))
-
-$(stardict_prefix)$(dictname).ifo: $(stardict_prefix)$(dictname).idx \
-	dictd2dic.out authorresp.out title.out sourceurl.out
-	@echo "Generating $@..."
-	@echo "StarDict's dict ifo file" > $@
-	@echo "version=2.4.2" >> $@
-	@echo "wordcount=$(wordcount)" >> $@
-	@echo "idxfilesize=$(idxfilesize)" >> $@
-	@echo "bookname=$(shell cat title.out)" >> $@
-	@echo "author=$(shell sed -e "s/ <.*>//" <authorresp.out)" >> $@
-	@echo "email=$(shell sed -e "s/.* <\(.*\)>/\1/" <authorresp.out)" >> $@
-	@echo "website=$(shell cat sourceurl.out)" >> $@
-	@echo "description=Converted to StarDict format by freedict.org" >> $@
-	@echo "date=$(shell date +%Y.%m.%d)" >> $@
-	@echo "sametypesequence=m" >> $@
-	@cat $@
 
 stardict: $(stardict_prefix)$(dictname).ifo
+
 
 $(BUILD_DIR)/stardict/freedict-$(dictname)-$(version)-stardict.tar.bz2: \
        	$(stardict_prefix)$(dictname).ifo \
@@ -388,10 +363,10 @@ release-stardict: \
 	$(BUILD_DIR)/stardict/freedict-$(dictname)-$(version)-stardict.tar.bz2
 
 clean::
-	rm -f $(dictname).idxhead $(stardict_prefix)$(dictname).idx.gz \
+	rm -f $(stardict_prefix)$(dictname).idx.gz \
 	$(stardict_prefix)$(dictname).dict.dz $(stardict_prefix)$(dictname).ifo \
 	$(BUILD_DIR)/stardict/freedict-$(dictname)-$(version)-stardict.tar.bz2 \
-	dictd2dic.out authorresp.out title.out sourceurl.out
+	pyglossary-stardict.out.out authorresp.out title.out sourceurl.out
 
 #######################
 #### Slob format for the Aard Android  dictionary client
@@ -404,7 +379,7 @@ $(BUILD_DIR)/slob/$(dictname)-$(version).slob: $(call dict_tei_source)
 	rm -f $@
 	$(call exc_pyscript,tei2slob,-w,$(BUILD_DIR)/slob,-o,$@,$<)
 
-$(call gen_release_path,slob): $(BUILD_DIR)/slob/$(dictname)-$(version).slob $(RELEASE_DIR) 
+$(call gen_release_path,slob): $(BUILD_DIR)/slob/$(dictname)-$(version).slob $(RELEASE_DIR)
 	cp $< $@
 
 # make the hash depend on the release file

--- a/mk/dicts.mk
+++ b/mk/dicts.mk
@@ -22,7 +22,7 @@ UNSUPPORTED_PLATFORMS = evolutionary
 endif
 
 
-available_platforms := src dictd slob
+available_platforms := src dictd slob stardict
 
 dictname ?= $(shell basename "$(shell pwd)")
 xsldir ?= $(FREEDICT_TOOLS)/xsl
@@ -334,25 +334,21 @@ release-src: $(call gen_release_path,src) $(call gen_release_hashpath,src)
 #### targets for StarDict platform
 ##################################
 
-# This tool comes with stardict
 PYGLOSSARY = pyglossary
 
-# Can we remove this?
-stardict_prefix =
-
-$(stardict_prefix)$(dictname).ifo $(stardict_prefix)$(dictname).idx.gz \
-	$(stardict_prefix)$(dictname).dict.dz pyglossary-stardict.out: $(dictname).tei
-	$(PYGLOSSARY) $(dictname).tei $(stardict_prefix)$(dictname).ifo >pyglossary-stardict.out
-	gzip -9 $(stardict_prefix)$(dictname).idx
+$(BUILD_DIR)/stardict/$(dictname).ifo $(BUILD_DIR)/stardict/$(dictname).idx.gz \
+	$(BUILD_DIR)/stardict/$(dictname).dict.dz pyglossary-stardict.out: $(dictname).tei
+	$(PYGLOSSARY) $(dictname).tei $(BUILD_DIR)/stardict/$(dictname).ifo >pyglossary-stardict.out
+	gzip -9 $(BUILD_DIR)/stardict/$(dictname).idx
 
 
-stardict: $(stardict_prefix)$(dictname).ifo
+build-stardict: $(BUILD_DIR)/stardict/$(dictname).ifo
 
 
 $(BUILD_DIR)/stardict/freedict-$(dictname)-$(version)-stardict.tar.bz2: \
-       	$(stardict_prefix)$(dictname).ifo \
-	$(stardict_prefix)$(dictname).dict.dz \
-	$(stardict_prefix)$(dictname).idx.gz
+       	$(BUILD_DIR)/stardict/$(dictname).ifo \
+	$(BUILD_DIR)/stardict/$(dictname).dict.dz \
+	$(BUILD_DIR)/stardict/$(dictname).idx.gz
 	@if [ ! -d $(BUILD_DIR)/stardict ]; then \
 		mkdir $(BUILD_DIR)/stardict; fi
 	tar -C .. -cvjf \
@@ -363,10 +359,10 @@ release-stardict: \
 	$(BUILD_DIR)/stardict/freedict-$(dictname)-$(version)-stardict.tar.bz2
 
 clean::
-	rm -f $(stardict_prefix)$(dictname).idx.gz \
-	$(stardict_prefix)$(dictname).dict.dz $(stardict_prefix)$(dictname).ifo \
+	rm -f $(BUILD_DIR)/stardict/$(dictname).idx.gz \
+	$(BUILD_DIR)/stardict/$(dictname).dict.dz $(BUILD_DIR)/stardict/$(dictname).ifo \
 	$(BUILD_DIR)/stardict/freedict-$(dictname)-$(version)-stardict.tar.bz2 \
-	pyglossary-stardict.out.out authorresp.out title.out sourceurl.out
+	pyglossary-stardict.out authorresp.out title.out sourceurl.out
 
 #######################
 #### Slob format for the Aard Android  dictionary client

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyICU>=2.3
 ankisync==0.1.6.3
 -e git://github.com/itkach/slob.git#egg=slob
 -e git://github.com/itkach/tei2slob.git#egg=tei2slob
+-e git://github.com/ilius/pyglossary.git#egg=pyglossary


### PR DESCRIPTION
Implement #21

Tested by running `make stardict` inside [eng-ara](https://github.com/freedict/fd-dictionaries/tree/master/eng-ara), it generates StarDict files (`eng-ara.ifo eng-ara.dict.dz eng-ara.idx.gz`). And validated by converting the StarDict to Tabfile.


I wasn't sure about virtualenv instructions on README so I didn't write it.